### PR TITLE
silence firmware warnings

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -138,7 +138,7 @@ fw-shipped-$(CONFIG_VIDEO_CPIA2) += cpia2/stv0672_vp4.bin
 fw-shipped-$(CONFIG_YAM) += yam/1200.bin yam/9600.bin
 
 TSPFIRMWARE_DIRECTORY = firmware/tsp_synaptics
-ifeq ($(shell test -d $(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
+ifeq ($(shell test -d $(srctree)/$(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
 fw-shipped-$(CONFIG_TOUCHSCREEN_SYNAPTICS_I2C_RMI) += tsp_synaptics/synaptics_b0_h.fw \
 	tsp_synaptics/synaptics_b0_fac.fw
 fw-shipped-$(CONFIG_TOUCHSCREEN_SYNAPTICS_I2C_DSX) += \
@@ -148,7 +148,7 @@ $(warning '$(TSPFIRMWARE_DIRECTORY)' directory dose not exist)
 endif
 
 TSPFIRMWARE_DIRECTORY = firmware/tsp_atmel
-ifeq ($(shell test -d $(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
+ifeq ($(shell test -d $(srctree)/$(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
 fw-shipped-$(CONFIG_TOUCHSCREEN_ATMEL_MXT2405) += tsp_atmel/mxt2405_gvlte_IL.fw \
 						tsp_atmel/mxt2405_gvlte_OF.fw \
 						tsp_atmel/mxt2405_gvlte_100ch.fw \
@@ -159,7 +159,7 @@ $(warning '$(TSPFIRMWARE_DIRECTORY)' directory dose not exist)
 endif
 
 TSPFIRMWARE_DIRECTORY = firmware/tsp_stm
-ifeq ($(shell test -d $(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
+ifeq ($(shell test -d $(srctree)/$(TSPFIRMWARE_DIRECTORY) && echo yes),yes)
 fw-shipped-$(CONFIG_TOUCHSCREEN_FTS) += tsp_stm/stm_s.fw tsp_stm/stm_t.fw tsp_stm/stm_tb.fw tsp_stm/stm_tb_integ.fw
 else
 $(warning '$(TSPFIRMWARE_DIRECTORY)' directory dose not exist)


### PR DESCRIPTION
silence the following warnings
```
/home/buildtest/android/system/kernel/samsung/a3xelte/firmware/Makefile:147: 'firmware/tsp_synaptics' directory dose not exist
/home/buildtest/android/system/kernel/samsung/a3xelte/firmware/Makefile:158: 'firmware/tsp_atmel' directory dose not exist
/home/buildtest/android/system/kernel/samsung/a3xelte/firmware/Makefile:165: 'firmware/tsp_stm' directory dose not exist

```