### PR TITLE
add option to set selinux to permissive at boot

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -3,9 +3,19 @@
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
 
+#ifdef CONFIG_SECURITY_SELINUX_PERMISSIVE
+#include <asm/setup.h>
+
+static char proc_cmdline[COMMAND_LINE_SIZE];
+#endif
+
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
+#ifdef CONFIG_SECURITY_SELINUX_PERMISSIVE
+	seq_printf(m, "%s\n", proc_cmdline);
+#else
 	seq_printf(m, "%s\n", saved_command_line);
+#endif
 	return 0;
 }
 
@@ -23,6 +33,25 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+#ifdef CONFIG_SECURITY_SELINUX_PERMISSIVE
+	char *a1, *a2;
+
+	a1 = strstr(saved_command_line, "androidboot.selinux=");
+	if (a1) {
+		a1 = strchr(a1, '=');
+		a2 = strchr(a1, ' ');
+		if (!a2) /* last argument on the cmdline */
+			a2 = "";
+
+		scnprintf(proc_cmdline, COMMAND_LINE_SIZE, "%.*spermissive%s",
+				(int)(a1 - saved_command_line + 1),
+				saved_command_line, a2);
+	}
+	else {
+		strncpy(proc_cmdline, saved_command_line, COMMAND_LINE_SIZE);
+	}
+#endif
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }

--- a/security/selinux/Kconfig
+++ b/security/selinux/Kconfig
@@ -8,6 +8,11 @@ config SECURITY_SELINUX
 	  You will also need a policy configuration and a labeled filesystem.
 	  If you are unsure how to answer this question, answer N.
 
+config SECURITY_SELINUX_PERMISSIVE
+	bool "set NSA SELinux to permissive at boot"
+	depends on SECURITY_SELINUX
+	default n
+
 config SECURITY_SELINUX_BOOTPARAM
 	bool "NSA SELinux boot parameter"
 	depends on SECURITY_SELINUX


### PR DESCRIPTION
atlest on the s5 neo the kernel/bootloader ignores what you set in te BoardConfig.mk
so we need to fake it to set it to permissive